### PR TITLE
QRコードの読み取り可能エリアを調整

### DIFF
--- a/ios/Classes/zxing/ZXingViewController.swift
+++ b/ios/Classes/zxing/ZXingViewController.swift
@@ -110,61 +110,6 @@ extension ZXingViewController {
         capture?.layer.frame = view.frame
     }
     
-    func barcodeFormatToString(format: ZXBarcodeFormat) -> String {
-        switch (format) {
-            case kBarcodeFormatAztec:
-                return "Aztec"
-            
-            case kBarcodeFormatCodabar:
-                return "CODABAR"
-            
-            case kBarcodeFormatCode39:
-                return "Code 39"
-            
-            case kBarcodeFormatCode93:
-                return "Code 93"
-            
-            case kBarcodeFormatCode128:
-                return "Code 128"
-            
-            case kBarcodeFormatDataMatrix:
-                return "Data Matrix"
-            
-            case kBarcodeFormatEan8:
-                return "EAN-8"
-            
-            case kBarcodeFormatEan13:
-                return "EAN-13"
-            
-            case kBarcodeFormatITF:
-                return "ITF"
-            
-            case kBarcodeFormatPDF417:
-                return "PDF417"
-            
-            case kBarcodeFormatQRCode:
-                return "QR Code"
-            
-            case kBarcodeFormatRSS14:
-                return "RSS 14"
-            
-            case kBarcodeFormatRSSExpanded:
-                return "RSS Expanded"
-            
-            case kBarcodeFormatUPCA:
-                return "UPCA"
-            
-            case kBarcodeFormatUPCE:
-                return "UPCE"
-            
-            case kBarcodeFormatUPCEANExtension:
-                return "UPC/EAN extension"
-            
-            default:
-                return "Unknown"
-            }
-    }
-    
     func adjustScanRect() {
         guard let captureLayer = capture?.layer as? AVCaptureVideoPreviewLayer else { return }
         // 読み取り可能エリアのサイズを定義

--- a/ios/Classes/zxing/ZXingViewController.swift
+++ b/ios/Classes/zxing/ZXingViewController.swift
@@ -64,7 +64,7 @@ extension ZXingViewController {
         capture = ZXCapture()
         guard let _capture = capture else { return }
         _capture.camera = _capture.back()
-        _capture.focusMode =  .continuousAutoFocus
+        _capture.focusMode = .continuousAutoFocus
         _capture.delegate = self
         
         view.backgroundColor = .black
@@ -118,10 +118,16 @@ extension ZXingViewController {
     }
     
     func applyRectOfInterest(orientation: UIInterfaceOrientation) {
-        guard var transformedVideoRect = scanView?.frame,
-            let cameraSessionPreset = capture?.sessionPreset
-            else { return }
+        guard let cameraSessionPreset = capture?.sessionPreset else { return }
         
+        // 読み取り可能エリアのサイズを定義
+        // おくすり連絡帳アプリ側で定義しているエリアのサイズに合わせる
+        //https://github.com/kkhs/pocket-musubi-native/blob/develop/lib/components/qr_code_reader/qr_code_reader.dart/#L213
+        let scanAreaSize: CGFloat = (view.bounds.width < 400 || view.bounds.height < 400) ? 225.0 : 300.0
+        let marginX = (view.bounds.width - scanAreaSize) * 0.5
+        let marginY = (view.bounds.height - scanAreaSize) * 0.5
+        var transformedVideoRect = CGRect(x: marginX, y: marginY, width: scanAreaSize, height: scanAreaSize)
+
         var scaleVideoX, scaleVideoY: CGFloat
         var videoHeight, videoWidth: CGFloat
         

--- a/ios/Classes/zxing/ZXingViewController.swift
+++ b/ios/Classes/zxing/ZXingViewController.swift
@@ -16,9 +16,6 @@ class ZXingViewController: UIViewController {
     
     // MARK: Properties
     
-    @IBOutlet weak var scanView: UIView?
-    @IBOutlet weak var resultLabel: UILabel?
-    
     fileprivate var capture: ZXCapture?
     
     fileprivate var isScanning: Bool?
@@ -70,9 +67,6 @@ extension ZXingViewController {
         view.backgroundColor = .black
         
         self.view.layer.addSublayer(_capture.layer)
-        guard let _scanView = scanView, let _resultLabel = resultLabel else { return }
-        self.view.bringSubview(toFront: _scanView)
-        self.view.bringSubview(toFront: _resultLabel)
     }
     
     func applyOrientation() {
@@ -233,11 +227,6 @@ extension ZXingViewController: ZXCaptureDelegate {
         isScanning = false
         
         let text = _result.text ?? "Unknow"
-        let format = barcodeFormatToString(format: _result.barcodeFormat)
-        
-        let displayStr = "Scanned !\nFormat: \(format)\nContents: \(text)"
-        resultLabel?.text = displayStr
-        
                 
         delegate?.metadataOutput(qrcode: .init(rawValue: text, data: NSData(bytes: rawBytes.array, length: Int(rawBytes.length))))
         


### PR DESCRIPTION
https://kakehashi.atlassian.net/browse/KN-637

## やったこと
- これまでは画面全体が読み取り範囲になっていたのを、「 」の範囲のみを読み取るように調整した。
- 合わせて不要なフィールドと関連コードを削除


## なぜやったか
画面全体が読み取り範囲になっていることで、複数QRコードが並んでいる場合にカメラ範囲に複数QRコードが入り、どのコードを読み取っているかわからない問題が発生するため
[参考スレ](https://kakehashi.slack.com/archives/C06LRQ3GXHD/p1709635723768269?thread_ts=1709511069.713869&cid=C06LRQ3GXHD)